### PR TITLE
feat(signal): send a signal to a running task

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ Both kinds share the `*.hcl`/`*.nomad` globs, so a directory may hold both. **Cl
 - `nd run` — compile + register, then watch the rollout (`--detach / -d` skips the watch). If a target is present as a dead job (stopped without purge), offers to purge it first; `--clean / -c` purges without prompting.
 - `nd update` - recreate a running job from its local file (stop, drain, purge, re-register, watch). Use for a changed job file or to force a fresh version. `--no-purge` keeps version history; `--force / -f` skips the prompt.
 - `nd stop` — stop/purge running jobs and watch the drain (`--detach`, `--no-shutdown-delay / -S`).
+- `nd signal` - send a signal to one running task (`-s SIGUSR1`), resolved through the same picker as `nd exec`. Pure API, no binary wrapper.
 - `nd volume register|delete|list` — manage dynamic host volumes from local specs.
 - `nd status` — cluster dashboard (jobs, nodes, volumes, deployments, evals), all fetched concurrently.
 
@@ -79,7 +80,7 @@ Reuse the shared helpers rather than reimplementing:
 
 - `commands/_common.py` — `VerboseOption`, `configure_verbosity`, `record_step`, `run_alloc_action` (exec/logs tail).
 - `ui/` — styles, panels, prompts, duration formatting, `live_panel.run_rows` (concurrent row orchestrator used by `stop`/`run`).
-- `targets/` — `resolve_targets(...)` for name-substring (contains) matching/multi-select; `alloc_target.py` for single-task exec/logs resolution.
+- `targets/` — `resolve_targets(...)` for name-substring (contains) matching/multi-select; `alloc_target.py` for single job/allocation/task resolution (`nd exec`, `nd logs`, `nd signal`).
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Run `nd --help`, or `nd <command> --help`, for the full option list at any time.
 | `nd stop [JOB]`             | Stop, and optionally purge, running jobs and watch them drain.                    |
 | `nd logs [JOB]`             | Stream, tail, or export a task's logs.                                            |
 | `nd exec [JOB] [-- CMD]`    | Open a shell inside a running task, or run one command in it.                     |
+| `nd signal [JOB] -s SIG`    | Send a signal to a running task, such as to trigger an on-demand action.          |
 | `nd clean`                  | Force garbage collection and reconcile job summaries.                             |
 | `nd volume register [NAME]` | Register host volumes on every eligible node.                                     |
 | `nd volume delete [NAME]`   | Delete registered host volumes matching the selected specs.                       |
@@ -172,6 +173,7 @@ touching the cluster:
 nd run --dry-run
 nd update web --dry-run
 nd stop web --dry-run
+nd signal web -s SIGHUP --dry-run
 nd volume register --dry-run
 ```
 
@@ -233,6 +235,34 @@ nd logs web --tail 100      # print the last 100 lines, no follow
 nd logs web --export run.log  # write the current logs to a file
 ```
 
+### Signaling a task
+
+Some services expose an out-of-band trigger over a POSIX signal. `nd signal` finds the
+running task and delivers one, picking the job, allocation, and task the same way
+`nd exec` does:
+
+```bash
+nd signal ezbak -s SIGUSR1      # ask a scheduled backup to run now
+nd signal ezbak -s usr1         # same thing; the name is case-insensitive
+nd signal -s SIGHUP             # pick the job from a list
+nd signal web -s SIGHUP -t api  # signal the "api" task, skipping the task prompt
+nd signal web -s SIGHUP -n      # show the target without sending anything
+```
+
+A success line means Nomad delivered the signal to the task. Whether the process acted
+on it is up to the process: it may be busy, or may not handle that signal at all. Check
+with `nd logs ezbak`.
+
+The name is checked against the fixed set Nomad's task drivers accept, which is not the
+same as your machine's signal list: `SIGCHLD` and `SIGURG` are refused even though your
+libc has them, and `SIGNULL` and `SIGIOT` are accepted even though it may not. A name
+outside that set is rejected before anything is sent, and the error lists the ones you
+can use.
+
+Signaling needs the `alloc-lifecycle` capability on the namespace. A token that works
+for every other `nd` command can still be refused here, so a "not authorized" error is
+worth checking against your ACL policy before you suspect the token itself.
+
 ### Stopping jobs
 
 `nd stop` confirms before it acts unless you pass `--force`. Use `--purge` to
@@ -274,6 +304,20 @@ nd stop web --force        # works unattended
 nd stop                    # fails: nothing named a job to stop
 nd stop web                # fails: nothing answered the confirmation
 ```
+
+`nd signal` takes no confirmation, so naming the job (and the task, when the job has
+more than one) is all it needs to run from cron, provided the job has a single running
+allocation. Nothing names an allocation, so a job running several always needs a
+terminal:
+
+```bash
+nd signal ezbak -s SIGUSR1        # works unattended
+nd signal ezbak -s SIGUSR1 -t db  # name the task too when the job runs several
+nd signal web -s SIGHUP           # fails when "web" has more than one allocation
+```
+
+A named job that is not running is an error, not a no-op, so a scheduled trigger fails
+loudly instead of silently doing nothing.
 
 ### Verbosity
 

--- a/src/nd/cli.py
+++ b/src/nd/cli.py
@@ -9,7 +9,18 @@ import typer
 from nclutils import pp
 
 from nd import __version__
-from nd.commands import clean, exec, logs, plan, run, status, stop, update, volume  # noqa: A004
+from nd.commands import (
+    clean,
+    exec,  # noqa: A004
+    logs,
+    plan,
+    run,
+    signal,
+    status,
+    stop,
+    update,
+    volume,
+)
 from nd.commands import list as list_cmd
 from nd.nomad import (
     NomadAuthError,
@@ -32,6 +43,7 @@ app.add_typer(run.app, name="run")
 app.add_typer(update.app, name="update")
 app.add_typer(logs.app, name="logs")
 app.add_typer(exec.app, name="exec")
+app.add_typer(signal.app, name="signal")
 app.add_typer(volume.app, name="volume")
 
 

--- a/src/nd/commands/signal.py
+++ b/src/nd/commands/signal.py
@@ -1,0 +1,162 @@
+"""The ``nd signal`` command: send a signal to a running task."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Annotated
+
+import typer
+from nclutils import pp
+
+from nd.commands._common import VerboseOption, configure_verbosity, record_step
+from nd.nomad import NomadClient, NomadConfig
+from nd.targets import resolve_with_client
+
+# The names every Nomad driver's SignalTask parses (consul-template's SignalLookup).
+# Deriving this from the local libc instead diverges both ways: it drops SIGNULL and
+# SIGIOT, which Nomad takes, and admits SIGCHLD and SIGURG, which Nomad deliberately
+# refuses, turning a usage error back into the opaque driver error this check avoids.
+_VALID_SIGNALS = frozenset(
+    {
+        "SIGABRT",
+        "SIGALRM",
+        "SIGBUS",
+        "SIGCONT",
+        "SIGFPE",
+        "SIGHUP",
+        "SIGILL",
+        "SIGINT",
+        "SIGIO",
+        "SIGIOT",
+        "SIGKILL",
+        "SIGNULL",
+        "SIGPIPE",
+        "SIGPROF",
+        "SIGQUIT",
+        "SIGSEGV",
+        "SIGSTOP",
+        "SIGSYS",
+        "SIGTERM",
+        "SIGTRAP",
+        "SIGTSTP",
+        "SIGTTIN",
+        "SIGTTOU",
+        "SIGUSR1",
+        "SIGUSR2",
+        "SIGWINCH",
+        "SIGXCPU",
+        "SIGXFSZ",
+    }
+)
+
+# allow_interspersed_args lets options follow the positional JOB (e.g. `nd signal web -s HUP`).
+app = typer.Typer(context_settings={"allow_interspersed_args": True})
+
+
+def _normalize_signal(value: str) -> str:
+    """Resolve a user-typed signal name to the canonical name Nomad expects.
+
+    Accept any case, with or without the ``SIG`` prefix, so ``usr1`` and ``SIGUSR1``
+    both reach Nomad as ``SIGUSR1``. Validating against the names Nomad itself accepts
+    turns a typo into a usage error before any request is sent, instead of an opaque
+    driver error from Nomad.
+
+    Returns:
+        str: The canonical, ``SIG``-prefixed uppercase signal name.
+
+    Raises:
+        typer.BadParameter: If the value names no known signal.
+    """
+    name = value.strip().upper()
+    if not name.startswith("SIG"):
+        name = f"SIG{name}"
+    if name not in _VALID_SIGNALS:
+        valid = ", ".join(sorted(_VALID_SIGNALS))
+        msg = f"unknown signal '{value}'; expected one of: {valid}"
+        raise typer.BadParameter(msg)
+    return name
+
+
+@app.callback(invoke_without_command=True)
+def signal(
+    ctx: typer.Context,
+    # Declared before JOB only because a required parameter cannot follow a defaulted
+    # one; JOB is still the sole positional.
+    signal_name: Annotated[
+        str,
+        typer.Option("--signal", "-s", help="Signal to send, e.g. SIGUSR1. Case-insensitive."),
+    ],
+    job: Annotated[
+        str | None,
+        typer.Argument(
+            help="Running job to signal; matches any job whose name contains this. "
+            "Omit to pick from a list."
+        ),
+    ] = None,
+    task: Annotated[
+        str | None,
+        typer.Option("--task", "-t", help="Target task; skips the task prompt."),
+    ] = None,
+    dry_run: Annotated[  # noqa: FBT002
+        bool,
+        typer.Option("--dry-run", "-n", help="Show the target that would be signaled."),
+    ] = False,
+    verbose: VerboseOption = 0,
+) -> None:
+    """Send a signal to a running task.
+
+    Resolves a running job, allocation, and task, prompting only where the choice is
+    ambiguous, then delivers the signal. Use it to trigger an action a task exposes
+    out of band, such as making a scheduled backup run now.
+
+    A success line means Nomad delivered the signal, not that the process acted on it.
+    Check the task's logs to see what it did.
+    """
+    verbose = configure_verbosity(ctx, verbose)
+    sig = _normalize_signal(signal_name)
+    config = NomadConfig.resolve()
+    asyncio.run(_run(config, job=job, task=task, sig=sig, dry_run=dry_run, verbose=verbose))
+
+
+async def _run(
+    config: NomadConfig,
+    *,
+    job: str | None,
+    task: str | None,
+    sig: str,
+    dry_run: bool,
+    verbose: int,
+) -> None:
+    """Resolve a live target and signal it, sharing one client between both steps.
+
+    Raises:
+        typer.Exit: If an argument matches nothing selectable, or a needed prompt
+            cannot be shown.
+    """
+    async with NomadClient.from_config(config) as client:
+        exit_code, target = await resolve_with_client(
+            client, job_arg=job, task_arg=task, running_only=True
+        )
+        if exit_code != 0:
+            raise typer.Exit(exit_code)
+        if target is None:
+            return
+
+        where = f"task {target.task} in alloc {target.alloc_id[:8]} ({target.job_name})"
+        if dry_run:
+            pp.dryrun(f"Would send {sig} to {where}")
+            return
+
+        with pp.step(f"Sending {sig} to {target.task}") as step:
+            await record_step(
+                client.allocations.signal(target.alloc_id, signal=sig, task=target.task),
+                step=step,
+                verbose=verbose,
+                method="POST",
+                path=f"/client/allocation/{target.alloc_id}/signal",
+            )
+
+    pp.success(
+        f"Sent {sig} to {where}",
+        details=[f"run `nd logs {target.job_name}` to see what the task did"],
+    )

--- a/src/nd/nomad/resources/allocations.py
+++ b/src/nd/nomad/resources/allocations.py
@@ -12,7 +12,7 @@ from nd.nomad.resources.base import BaseResource
 
 
 class AllocationsResource(BaseResource):
-    """Read access to Nomad allocations."""
+    """Read and lifecycle access to Nomad allocations."""
 
     async def list(self) -> builtins.list[AllocListStub]:
         """List all allocations (``GET /v1/allocations``), following pagination."""
@@ -22,3 +22,21 @@ class AllocationsResource(BaseResource):
         """Read a single allocation (``GET /v1/allocation/:id``)."""
         response = await self._transport.request("GET", f"/allocation/{alloc_id}")
         return self._decode(response, Allocation)
+
+    async def signal(self, alloc_id: str, *, signal: str, task: str) -> None:
+        """Send a signal to one task in an allocation.
+
+        ``POST /v1/client/allocation/:alloc_id/signal``. Use to trigger an out-of-band
+        action in a running task, such as making a scheduled job run now. Requires the
+        ``alloc-lifecycle`` ACL capability, which the read-only endpoints do not.
+
+        Args:
+            alloc_id: Allocation carrying the task.
+            signal: Canonical signal name to send, such as ``SIGUSR1``.
+            task: Name of the task to signal.
+        """
+        await self._transport.request(
+            "POST",
+            f"/client/allocation/{alloc_id}/signal",
+            json={"Signal": signal, "Task": task},
+        )

--- a/src/nd/targets/__init__.py
+++ b/src/nd/targets/__init__.py
@@ -1,8 +1,9 @@
 """Resolve which job, allocation, and task a command should act on.
 
 `selection` is the generic name-substring matching shared by every command that takes
-an optional name argument; `alloc_target` builds on it to resolve an exec/logs target
-through the API client. This module re-exports their public surface.
+an optional name argument; `alloc_target` builds on it to resolve a single job,
+allocation, and task through the API client. This module re-exports their public
+surface.
 """
 
 from nd.targets.alloc_target import (
@@ -10,6 +11,7 @@ from nd.targets.alloc_target import (
     SelectionError,
     resolve_alloc_task,
     resolve_target,
+    resolve_with_client,
 )
 from nd.targets.selection import (
     TargetResolution,
@@ -27,6 +29,7 @@ __all__ = [
     "resolve_alloc_task",
     "resolve_target",
     "resolve_targets",
+    "resolve_with_client",
     "select_candidates",
     "select_one_candidate",
 ]

--- a/src/nd/targets/alloc_target.py
+++ b/src/nd/targets/alloc_target.py
@@ -1,11 +1,10 @@
 """Resolve a job, allocation, and task through the Nomad API client.
 
-Shared by ``nd exec`` and ``nd logs``: both pick a single job (by optional name
+Shared by every command that acts on a single task: each picks a job (by optional name
 substring), then its allocation (auto when one, prompt when several), then a task
-(auto when one, prompt when several, or a ``--task`` override). ``nd exec`` needs a
-live target, so it resolves running jobs/allocations/tasks only; ``nd logs`` passes
-``running_only=False`` so a dead or completed task's logs stay reachable. The
-resolved target is handed to a ``NomadBinary`` (the binary layer) to act on.
+(auto when one, prompt when several, or a ``--task`` override). Commands that need a
+live target resolve running jobs/allocations/tasks only; ``nd logs`` passes
+``running_only=False`` so a dead or completed task's logs stay reachable.
 """
 
 from __future__ import annotations
@@ -31,7 +30,7 @@ class SelectionError(Exception):
 
 @dataclass(frozen=True)
 class ResolvedTarget:
-    """A fully resolved exec/logs target: the chosen job, allocation, and task."""
+    """A fully resolved single-task target: the chosen job, allocation, and task."""
 
     job_name: str
     alloc_id: str
@@ -85,11 +84,11 @@ async def resolve_alloc_task(
 ) -> ResolvedTarget | None:
     """Resolve a job, allocation, and task, prompting only where ambiguous.
 
-    With ``running_only`` (the default, used by ``nd exec``) only running jobs,
-    allocations, and tasks are offered. ``nd logs`` passes ``running_only=False`` so a
-    dead or completed task's logs are still reachable. Returns the resolved target, or
-    None when there is nothing to act on or the user cancels a prompt (the caller exits
-    0). Each of those cases reports itself.
+    With ``running_only`` (the default) only running jobs, allocations, and tasks are
+    offered. ``nd logs`` passes ``running_only=False`` so a dead or completed task's logs
+    are still reachable. Returns the resolved target, or None when nothing is selectable
+    and no job was named, or the user cancels a prompt (the caller exits 0). Each of
+    those cases reports itself.
 
     Raises:
         SelectionError: If an argument matches nothing selectable (the caller exits 1).
@@ -101,7 +100,9 @@ async def resolve_alloc_task(
     jobs = await client.jobs.list()
     candidates = target_filter.jobs(jobs)
     pp.debug(f"GET /v1/jobs -> {len(candidates)} selectable of {len(jobs)} jobs")
-    if not candidates:
+    # A named job that is not selectable must fail loudly even when nothing is running,
+    # so only the unnamed case exits soft; the named one falls through to the miss below.
+    if not candidates and job_arg is None:
         pp.info(f"No {qualifier}jobs")
         return None
 
@@ -157,6 +158,28 @@ async def resolve_alloc_task(
     return ResolvedTarget(job_name=job.name, alloc_id=alloc.id, task=task)
 
 
+async def resolve_with_client(
+    client: NomadClient, *, job_arg: str | None, task_arg: str | None, running_only: bool = True
+) -> tuple[int, ResolvedTarget | None]:
+    """Resolve a target through an already-open client, mapping failures to an exit code.
+
+    Resolve on a client the caller owns, so the connection stays open past resolution and
+    the caller can act on the target over it. :func:`resolve_target` wraps this for
+    callers that only need the target. Returns ``(exit_code, target)``: a target with
+    code 0 on success, ``(0, None)`` when there is nothing to act on or the user cancels,
+    and ``(1, None)`` when an argument matched nothing or a needed prompt could not be
+    shown.
+    """
+    try:
+        target = await resolve_alloc_task(
+            client, job_arg=job_arg, task_arg=task_arg, running_only=running_only
+        )
+    except (SelectionError, PromptUnavailableError) as exc:
+        pp.error(str(exc))
+        return 1, None
+    return 0, target
+
+
 async def resolve_target(
     config: NomadConfig, *, job_arg: str | None, task_arg: str | None, running_only: bool = True
 ) -> tuple[int, ResolvedTarget | None]:
@@ -168,11 +191,6 @@ async def resolve_target(
     act on or the user cancels, and ``(1, None)`` when an argument matched nothing.
     """
     async with NomadClient.from_config(config) as client:
-        try:
-            target = await resolve_alloc_task(
-                client, job_arg=job_arg, task_arg=task_arg, running_only=running_only
-            )
-        except (SelectionError, PromptUnavailableError) as exc:
-            pp.error(str(exc))
-            return 1, None
-    return 0, target
+        return await resolve_with_client(
+            client, job_arg=job_arg, task_arg=task_arg, running_only=running_only
+        )

--- a/tests/unit/commands/test_signal.py
+++ b/tests/unit/commands/test_signal.py
@@ -1,0 +1,269 @@
+"""Tests for the nd signal command."""
+
+import json
+import re
+
+import httpx
+import pytest
+import respx
+import typer
+from nclutils import pp
+from rich.console import Console
+
+from nd.cli import app
+from nd.commands.signal import _normalize_signal
+from nd.targets import ResolvedTarget
+
+_ADDR = "http://nomad.test:4646"
+
+
+def _patch_resolver(
+    monkeypatch, *, target: ResolvedTarget | None, exit_code: int = 0
+) -> dict[str, object]:
+    """Patch resolve_with_client so tests exercise the command, not the picker.
+
+    Mirrors the ``(exit_code, target)`` contract ``resolve_with_client`` returns: a
+    non-zero ``exit_code`` simulates a selection failure or an unavailable prompt, both
+    of which it has already reported via ``pp.error`` before returning. Returns the dict
+    the fake populates with each call's arguments so a test can assert on it without
+    reading shared module state.
+    """
+    from nd.commands import signal as signal_mod
+
+    calls: dict[str, object] = {}
+
+    async def _fake_resolve(
+        client, *, job_arg, task_arg, running_only=True
+    ) -> tuple[int, ResolvedTarget | None]:
+        calls.update(job_arg=job_arg, task_arg=task_arg, running_only=running_only)
+        return exit_code, target
+
+    monkeypatch.setattr(signal_mod, "resolve_with_client", _fake_resolve)
+    return calls
+
+
+def _isolate_config(monkeypatch, tmp_path) -> None:
+    """Point NomadConfig.resolve() at the mock address, not a real ~/.config/nd."""
+    monkeypatch.setenv("NOMAD_ADDR", _ADDR)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+
+@pytest.mark.parametrize(
+    ("given", "expected"),
+    [
+        ("SIGUSR1", "SIGUSR1"),
+        ("sigusr1", "SIGUSR1"),
+        ("USR1", "SIGUSR1"),
+        ("usr1", "SIGUSR1"),
+        (" sigterm ", "SIGTERM"),
+        ("hup", "SIGHUP"),
+        # Nomad accepts these; the local libc has no member for either
+        ("signull", "SIGNULL"),
+        ("iot", "SIGIOT"),
+    ],
+)
+def test_normalize_signal_accepted_forms(given, expected):
+    """Verify signal names normalize to their canonical SIG-prefixed uppercase form."""
+    # Given a user-typed signal name in any case, with or without the SIG prefix
+    # When normalizing it
+    result = _normalize_signal(given)
+
+    # Then it becomes the canonical name Nomad expects
+    assert result == expected
+
+
+@pytest.mark.parametrize("given", ["sigwat", "nope", "", "SIG", "SIGCHLD", "sigurg"])
+def test_normalize_signal_rejects_unknown_names(given):
+    """Verify a name Nomad will not deliver is a usage error rather than a request to it."""
+    # Given a signal name Nomad's drivers do not accept
+    # When normalizing it, Then it is rejected as a bad parameter
+    with pytest.raises(typer.BadParameter):
+        _normalize_signal(given)
+
+
+def test_signal_sends_the_signal_to_the_resolved_task(
+    httpx2_mock: respx.Router, monkeypatch, tmp_path, typer_runner
+):
+    """Verify the resolved allocation and task receive the requested signal."""
+    # Given an isolated config, a resolved target, and a mocked signal endpoint
+    _isolate_config(monkeypatch, tmp_path)
+    _patch_resolver(monkeypatch, target=ResolvedTarget("backup", "alloc-1", "ezbak"))
+    route = httpx2_mock.post(f"{_ADDR}/v1/client/allocation/alloc-1/signal").respond(json={})
+
+    # When signaling the job by name
+    result = typer_runner.invoke(app, ["signal", "backup", "-s", "SIGUSR1"])
+
+    # Then it exits zero and posts the signal for that exact task
+    assert result.exit_code == 0
+    assert json.loads(route.calls.last.request.content) == {"Signal": "SIGUSR1", "Task": "ezbak"}
+
+
+def test_signal_normalizes_the_signal_before_sending(
+    httpx2_mock: respx.Router, monkeypatch, tmp_path, typer_runner
+):
+    """Verify a lowercase unprefixed signal reaches Nomad in canonical form."""
+    # Given an isolated config, a resolved target, and a mocked signal endpoint
+    _isolate_config(monkeypatch, tmp_path)
+    _patch_resolver(monkeypatch, target=ResolvedTarget("backup", "alloc-1", "ezbak"))
+    route = httpx2_mock.post(f"{_ADDR}/v1/client/allocation/alloc-1/signal").respond(json={})
+
+    # When passing the signal as "usr1"
+    result = typer_runner.invoke(app, ["signal", "backup", "-s", "usr1"])
+
+    # Then Nomad is sent SIGUSR1
+    assert result.exit_code == 0
+    assert json.loads(route.calls.last.request.content)["Signal"] == "SIGUSR1"
+
+
+def test_signal_resolves_only_running_targets(
+    httpx2_mock: respx.Router, monkeypatch, tmp_path, typer_runner
+):
+    """Verify the picker is restricted to running jobs, allocations, and tasks."""
+    # Given an isolated config, a resolved target, and a mocked signal endpoint
+    _isolate_config(monkeypatch, tmp_path)
+    calls = _patch_resolver(monkeypatch, target=ResolvedTarget("backup", "alloc-1", "ezbak"))
+    httpx2_mock.post(f"{_ADDR}/v1/client/allocation/alloc-1/signal").respond(json={})
+
+    # When signaling with an explicit task
+    result = typer_runner.invoke(app, ["signal", "backup", "-s", "SIGUSR1", "-t", "ezbak"])
+
+    # Then the resolver was asked for live targets only, and got both arguments
+    assert result.exit_code == 0
+    assert calls == {"job_arg": "backup", "task_arg": "ezbak", "running_only": True}
+
+
+def test_signal_requires_the_signal_option(monkeypatch, tmp_path, typer_runner):
+    """Verify omitting -s is a usage error rather than a defaulted signal."""
+    # Given an isolated config
+    _isolate_config(monkeypatch, tmp_path)
+
+    # When invoking with no signal
+    result = typer_runner.invoke(app, ["signal", "backup"])
+
+    # Then it is a usage error
+    assert result.exit_code == 2
+
+
+def test_signal_rejects_an_unknown_signal_before_any_request(
+    httpx2_mock: respx.Router, monkeypatch, tmp_path, typer_runner
+):
+    """Verify a misspelled signal fails locally without contacting Nomad."""
+    # Given an isolated config and a resolved target
+    _isolate_config(monkeypatch, tmp_path)
+    _patch_resolver(monkeypatch, target=ResolvedTarget("backup", "alloc-1", "ezbak"))
+
+    # When passing a signal that does not exist
+    result = typer_runner.invoke(app, ["signal", "backup", "-s", "SIGWAT"])
+
+    # Then it is a usage error and nothing was sent
+    assert result.exit_code == 2
+    assert not httpx2_mock.calls
+
+
+def test_signal_dry_run_resolves_but_sends_nothing(
+    httpx2_mock: respx.Router, monkeypatch, tmp_path, typer_runner
+):
+    """Verify --dry-run resolves the target, then reports it without signaling it."""
+    # Given an isolated config and a resolved target
+    _isolate_config(monkeypatch, tmp_path)
+    calls = _patch_resolver(monkeypatch, target=ResolvedTarget("backup", "alloc-1", "ezbak"))
+
+    # When running with --dry-run
+    result = typer_runner.invoke(app, ["signal", "backup", "-s", "SIGUSR1", "--dry-run"])
+
+    # Then it exits zero, having resolved the target but sent nothing
+    assert result.exit_code == 0
+    assert calls == {"job_arg": "backup", "task_arg": None, "running_only": True}
+    assert not httpx2_mock.calls
+
+
+def test_signal_honors_a_nonzero_resolver_exit_code(
+    httpx2_mock: respx.Router, monkeypatch, tmp_path, typer_runner
+):
+    """Verify a non-zero code from the resolver ends the command without signaling."""
+    # Given an isolated config and a resolver reporting a selection failure
+    _isolate_config(monkeypatch, tmp_path)
+    _patch_resolver(monkeypatch, target=None, exit_code=1)
+
+    # When signaling that name
+    result = typer_runner.invoke(app, ["signal", "x", "-s", "SIGUSR1"])
+
+    # Then it exits 1 and nothing was sent
+    assert result.exit_code == 1
+    assert not httpx2_mock.calls
+
+
+def test_signal_named_job_not_running_exits_one(
+    httpx2_mock: respx.Router, monkeypatch, tmp_path, typer_runner
+):
+    """Verify naming a job that is not running fails loudly rather than exiting zero."""
+    # Given an isolated config and a cluster whose only job, matching the name, is dead
+    _isolate_config(monkeypatch, tmp_path)
+    httpx2_mock.get(f"{_ADDR}/v1/jobs").mock(
+        return_value=httpx.Response(
+            200,
+            json=[
+                {
+                    "ID": "ezbak",
+                    "Name": "ezbak",
+                    "Type": "batch",
+                    "Status": "dead",
+                    "Priority": 50,
+                    "CreateIndex": 1,
+                    "ModifyIndex": 2,
+                }
+            ],
+        )
+    )
+
+    # When signaling it unattended
+    result = typer_runner.invoke(app, ["signal", "ezbak", "-s", "SIGUSR1"])
+
+    # Then it exits 1 and never posts a signal
+    assert result.exit_code == 1
+    assert not [c for c in httpx2_mock.calls if c.request.method == "POST"]
+
+
+def test_signal_cancelled_selection_exits_zero(
+    httpx2_mock: respx.Router, monkeypatch, tmp_path, typer_runner
+):
+    """Verify cancelling the picker exits zero without signaling."""
+    # Given an isolated config and a resolver reporting nothing selected
+    _isolate_config(monkeypatch, tmp_path)
+    _patch_resolver(monkeypatch, target=None)
+
+    # When the user cancels
+    result = typer_runner.invoke(app, ["signal", "backup", "-s", "SIGUSR1"])
+
+    # Then it exits zero and nothing was sent
+    assert result.exit_code == 0
+    assert not httpx2_mock.calls
+
+
+def test_signal_success_message_claims_delivery_only(
+    httpx2_mock: respx.Router, monkeypatch, tmp_path, typer_runner
+):
+    """Verify the success line reports delivery, never that the signal acted on the task."""
+    # Given an isolated config, a resolved target, and a mocked signal endpoint
+    _isolate_config(monkeypatch, tmp_path)
+    _patch_resolver(monkeypatch, target=ResolvedTarget("backup", "alloc-1", "ezbak"))
+    httpx2_mock.post(f"{_ADDR}/v1/client/allocation/alloc-1/signal").respond(json={})
+    capture = Console(theme=pp.THEME, record=True, force_terminal=True, width=100)
+    emitter = pp.Emitter(console=capture, err_console=capture)
+    original = pp.get_default()
+    pp.set_default(emitter)
+
+    # When signaling the resolved task
+    try:
+        result = typer_runner.invoke(app, ["signal", "backup", "-s", "SIGUSR1"])
+    finally:
+        pp.set_default(original)
+
+    # Then the success line says the signal was sent, and never claims it acted on the task
+    text = capture.export_text()
+    assert result.exit_code == 0
+    assert "Sent SIGUSR1 to task ezbak" in text
+    lowered = text.lower()
+    # Whole words only: these claims are substrings of ordinary words like "branch"
+    for claim in ("triggered", "ran", "started"):
+        assert not re.search(rf"\b{claim}\b", lowered)

--- a/tests/unit/nomad/resources/test_allocations.py
+++ b/tests/unit/nomad/resources/test_allocations.py
@@ -1,6 +1,7 @@
 """Tests for the allocations resource."""
 
 import asyncio
+import json
 
 import respx
 
@@ -64,3 +65,21 @@ def test_read_decodes_task_states(httpx2_mock: respx.Router):
 
     # Then the task state decodes
     assert alloc.task_states["server"].state == "running"
+
+
+def test_signal_posts_signal_and_task(httpx2_mock: respx.Router):
+    """Verify allocations.signal posts the signal and task name to the client endpoint."""
+    # Given a mocked signal endpoint returning Nomad's empty object
+    route = httpx2_mock.post(f"{_ADDR}/v1/client/allocation/a1/signal").respond(json={})
+    resource = AllocationsResource(AsyncTransport(NomadConfig(address=_ADDR)))
+
+    # When signaling a named task
+    async def run() -> None:
+        await resource.signal("a1", signal="SIGUSR1", task="server")
+        await resource._transport.aclose()
+
+    asyncio.run(run())
+
+    # Then the request carries both fields in Nomad's PascalCase form
+    assert route.calls.last.request.url.path == "/v1/client/allocation/a1/signal"
+    assert json.loads(route.calls.last.request.content) == {"Signal": "SIGUSR1", "Task": "server"}

--- a/tests/unit/test_alloc_target.py
+++ b/tests/unit/test_alloc_target.py
@@ -8,7 +8,12 @@ import respx
 
 from nd.nomad.client import NomadClient
 from nd.nomad.config import NomadConfig
-from nd.targets.alloc_target import ResolvedTarget, SelectionError, resolve_alloc_task
+from nd.targets.alloc_target import (
+    ResolvedTarget,
+    SelectionError,
+    resolve_alloc_task,
+    resolve_with_client,
+)
 from nd.ui.prompts import PromptUnavailableError
 
 _ADDR = "http://nomad.test:4646"
@@ -49,6 +54,15 @@ def _resolve(**kwargs) -> ResolvedTarget | None:
         config = NomadConfig(address=_ADDR)
         async with NomadClient.from_config(config) as client:
             return await resolve_alloc_task(client, **kwargs)
+
+    return asyncio.run(_run())
+
+
+def _resolve_with_client(**kwargs) -> tuple[int, ResolvedTarget | None]:
+    async def _run() -> tuple[int, ResolvedTarget | None]:
+        config = NomadConfig(address=_ADDR)
+        async with NomadClient.from_config(config) as client:
+            return await resolve_with_client(client, **kwargs)
 
     return asyncio.run(_run())
 
@@ -118,8 +132,8 @@ def test_resolve_bad_task_arg_raises(httpx2_mock: respx.Router):
         _resolve(job_arg="web", task_arg="nope")
 
 
-def test_resolve_no_running_jobs_returns_none(httpx2_mock: respx.Router):
-    """Verify no running jobs returns None with a soft exit."""
+def test_resolve_no_running_jobs_without_a_name_returns_none(httpx2_mock: respx.Router):
+    """Verify no running jobs and no job argument returns None with a soft exit."""
     # Given only dead jobs (no running jobs)
     httpx2_mock.get(f"{_ADDR}/v1/jobs").mock(
         return_value=httpx.Response(200, json=_jobs_payload(("web", "dead")))
@@ -130,6 +144,18 @@ def test_resolve_no_running_jobs_returns_none(httpx2_mock: respx.Router):
 
     # Then the result is None (soft exit 0)
     assert result is None
+
+
+def test_resolve_named_job_with_no_running_jobs_raises(httpx2_mock: respx.Router):
+    """Verify naming a job raises even when nothing at all is running."""
+    # Given a cluster whose only job, matching the argument, is dead
+    httpx2_mock.get(f"{_ADDR}/v1/jobs").mock(
+        return_value=httpx.Response(200, json=_jobs_payload(("web", "dead")))
+    )
+
+    # When resolving with that name, Then it is a hard error, not a silent no-op
+    with pytest.raises(SelectionError, match="No running job matching 'web'"):
+        _resolve(job_arg="web", task_arg=None)
 
 
 def test_resolve_running_only_false_allows_dead_target(httpx2_mock: respx.Router):
@@ -225,3 +251,70 @@ def test_resolve_unambiguous_target_needs_no_terminal(monkeypatch, httpx2_mock: 
     # When resolving, Then no prompt is needed and the target resolves
     target = _resolve(job_arg="web", task_arg=None)
     assert target == ResolvedTarget(job_name="web", alloc_id="alloc-1", task="server")
+
+
+def test_resolve_with_client_returns_the_target_and_zero(httpx2_mock: respx.Router):
+    """Verify a resolved target comes back paired with a zero exit code."""
+    # Given exactly one running job, allocation, and task
+    httpx2_mock.get(f"{_ADDR}/v1/jobs").mock(
+        return_value=httpx.Response(200, json=_jobs_payload(("web", "running")))
+    )
+    httpx2_mock.get(f"{_ADDR}/v1/job/web/allocations").mock(
+        return_value=httpx.Response(
+            200, json=[_alloc_payload("alloc-1", tasks={"server": "running"})]
+        )
+    )
+
+    # When resolving through an open client
+    exit_code, target = _resolve_with_client(job_arg="web", task_arg=None)
+
+    # Then the caller gets the target and a success code
+    assert exit_code == 0
+    assert target == ResolvedTarget(job_name="web", alloc_id="alloc-1", task="server")
+
+
+def test_resolve_with_client_maps_a_selection_failure_to_one(httpx2_mock: respx.Router):
+    """Verify a SelectionError becomes a (1, None) result instead of propagating."""
+    # Given a running job that does not match the argument
+    httpx2_mock.get(f"{_ADDR}/v1/jobs").mock(
+        return_value=httpx.Response(200, json=_jobs_payload(("web", "running")))
+    )
+
+    # When resolving with a non-matching arg
+    result = _resolve_with_client(job_arg="zzz", task_arg=None)
+
+    # Then the failure is reported as an exit code, not raised at the caller
+    assert result == (1, None)
+
+
+def test_resolve_with_client_maps_an_unavailable_prompt_to_one(
+    monkeypatch, httpx2_mock: respx.Router
+):
+    """Verify a PromptUnavailableError becomes a (1, None) result instead of propagating."""
+    # Given two running jobs matching the argument and a session that cannot prompt
+    httpx2_mock.get(f"{_ADDR}/v1/jobs").mock(
+        return_value=httpx.Response(
+            200, json=_jobs_payload(("web-api", "running"), ("web-ui", "running"))
+        )
+    )
+    monkeypatch.setattr("nd.ui.prompts.can_prompt", lambda: False)
+
+    # When resolving an ambiguous name
+    result = _resolve_with_client(job_arg="web", task_arg=None)
+
+    # Then the failure is reported as an exit code, not raised at the caller
+    assert result == (1, None)
+
+
+def test_resolve_with_client_passes_through_a_soft_exit(httpx2_mock: respx.Router):
+    """Verify nothing selectable and no job argument yields a zero code and no target."""
+    # Given only dead jobs
+    httpx2_mock.get(f"{_ADDR}/v1/jobs").mock(
+        return_value=httpx.Response(200, json=_jobs_payload(("web", "dead")))
+    )
+
+    # When resolving with no job arg
+    result = _resolve_with_client(job_arg=None, task_arg=None)
+
+    # Then the caller is told to exit zero with nothing to act on
+    assert result == (0, None)


### PR DESCRIPTION
Add `nd signal`, which sends a signal to a running task, resolving the
job, allocation, and task through the same picker `nd exec` uses. Signal
names are accepted in any case and with or without the `SIG` prefix, and
are validated against the fixed set Nomad's task drivers parse, so a name
Nomad would refuse fails as a usage error before anything is sent.

A success line reports delivery only. Whether the receiving process acts
on the signal is not visible to the caller, so the output never claims
more than that Nomad handed it over.

## Changes

- `nd signal [JOB] -s SIGNAL [--task/-t] [--dry-run/-n]`, registered in
  the root CLI. Targeting matches `nd exec`: optional name substring,
  prompts only where the choice is ambiguous.
- `AllocationsResource.signal()` posts to
  `/v1/client/allocation/:id/signal`. This is the first write method on
  that resource and needs the `alloc-lifecycle` ACL capability, which the
  read-only endpoints do not. A token that works for every other `nd`
  command can still be refused here.
- No dependency on the local `nomad` binary, unlike `nd exec` and
  `nd logs` — the HTTP API covers this operation fully.
- Target resolution splits into `resolve_with_client()`, taking a
  caller-owned client so one connection spans resolving the target and
  acting on it. `resolve_target()` is now a thin wrapper over it.
- Naming a job that is not running is an error across `nd signal`,
  `nd exec`, and `nd logs`, so an unattended run cannot report success
  having done nothing.
- A job with more than one running allocation still prompts for the
  allocation and so cannot be signaled unattended; there is no `--alloc`
  selector yet. The README's cron guidance says so.

## Testing

`uv run duty test` 410 passing, `uv run duty lint` clean.

Not covered by CI: the accepted signal list was checked against
consul-template's `SignalLookup` (28 names), which is what Nomad's
drivers parse. `SIGCHLD` and `SIGURG` are absent from it and are now
rejected locally; `SIGNULL` and `SIGIOT` are present and are now
accepted despite having no libc member.
